### PR TITLE
remove td-watson from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,3 @@ mappings:
 
 `$ watson-jira --help`
 
-Will install TD-Watson https://github.com/TailorDev/Watson as one of its dependencies, not surprisingly.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     license='MIT',
     packages=['watson_jira', 'watson_jira.src'],
     install_requires=[
-        'td-watson',
         'python-dateutil',
         'click==8.1.3',
         'simplejson',


### PR DESCRIPTION
The python package isn't needed as currently a shell command is used to get Watson logs. This prevents a bug where the pip installed version of Watson can override the brew install version.